### PR TITLE
Crown 248 - Transfer the mail service from sendgrid to AWS SES

### DIFF
--- a/src/main/java/org/crown/service/MailService.java
+++ b/src/main/java/org/crown/service/MailService.java
@@ -57,15 +57,16 @@ public class MailService {
 
     @Async
     public void sendEmail(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
-        log.debug("Send email[multipart '{}' and html '{}'] to '{}' with subject '{}' and content={}",
-            isMultipart, isHtml, to, subject, content);
+        String emailFrom = jHipsterProperties.getMail().getFrom();
+        log.debug("Send email[multipart '{}' and html '{}'] from '{}' to '{}' with subject '{}' and content={}",
+            isMultipart, isHtml, emailFrom, to, subject, content);
 
         // Prepare message using a Spring helper
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         try {
             MimeMessageHelper message = new MimeMessageHelper(mimeMessage, isMultipart, StandardCharsets.UTF_8.name());
             message.setTo(to);
-            message.setFrom(jHipsterProperties.getMail().getFrom());
+            message.setFrom(emailFrom);
             message.setSubject(subject);
             message.setText(content, isHtml);
             javaMailSender.send(mimeMessage);

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -45,10 +45,10 @@ spring:
       uri: ${MONGODB_URI}
       database: crown
   mail:
-    host: smtp.sendgrid.net
+    host: email-smtp.ca-central-1.amazonaws.com
     port: 25
-    username: apikey
-    password: ${MAIL_KEY}
+    username: ${SES_SMTP_USERNAME}
+    password: ${SES_SMTP_PASSWORD}
   messages:
     cache-duration: PT1S # 1 second, see the ISO 8601 standard
   thymeleaf:
@@ -86,6 +86,7 @@ jhipster:
       # security key (this key should be unique for your application, and kept secret)
       key: 2a84683611374cce7d7e793936e596c1efd64843bf46298bec94cb0147e5576e6163f440a159d97afaa1173b066acaedb8aa
   mail: # specific JHipster mail property, for standard properties see MailProperties
+    from: info@needmoremed.com
     base-url: http://127.0.0.1:8080
   metrics:
     logs: # Reports metrics in the logs

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -37,10 +37,10 @@ spring:
       database: crown
 
   mail:
-    host: smtp.sendgrid.net
+    host: email-smtp.ca-central-1.amazonaws.com
     port: 25
-    username: apikey
-    password: ${SENDGRID_KEY}
+    username: ${SES_SMTP_USERNAME}
+    password: ${SES_SMTP_PASSWORD}
 
   thymeleaf:
     cache: true
@@ -95,6 +95,7 @@ jhipster:
       # security key (this key should be unique for your application, and kept secret)
       key: 2a84683611374cce7d7e793936e596c1efd64843bf46298bec94cb0147e5576e6163f440a159d97afaa1173b066acaedb8aa
   mail: # specific JHipster mail property, for standard properties see MailProperties
+    from: info@needmoremed.com
     base-url: https://crown-dev.herokuapp.com # Modify according to your server's URL
   metrics:
     logs: # Reports metrics in the logs

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -29,7 +29,11 @@ spring:
         path:
           home: target/elasticsearch
   mail:
-    host: localhost
+    host: email-smtp.ca-central-1.amazonaws.com
+    port: 25
+    username: ${SES_SMTP_USERNAME}
+    password: ${SES_SMTP_PASSWORD}
+
   main:
     allow-bean-definition-overriding: true
   messages:
@@ -50,6 +54,11 @@ spring:
         size: 1
   thymeleaf:
     mode: HTML
+
+azure:
+  accountName: crownwebapp
+  endpoint: https://crownwebapp.blob.core.windows.net
+  accountKey: ${AZURE_ACCOUNT_KEY}
 
 server:
   port: 10344
@@ -73,7 +82,7 @@ jhipster:
       port: 5000
       queue-size: 512
   mail:
-    from: test@localhost
+    from: info@needmoremed.com
     base-url: http://127.0.0.1:8080
   security:
     remember-me:


### PR DESCRIPTION
Transfer the mail service from sendgrid to AWS SES.
After setting the configuration to AWS SES console, we were given the smtp credentials needed in order to send emails through SES. Those credentials should be set as env variables for our app.

Also, in order to send emails, the sender should be a verified email account. For that reason, we need to consider which accounts we should verify. Moreover, we can verify our whole domain so as to give access to all the emails we have under this domain.

Finally, SES starts functioning in a AWS sandbox, in which the receivers of the mails should be verified as well. I verified an account of mine, just for testing and it worked as expected!
In order to move out of AWS SES sandbox, a case should be open to their support and within 24 hours it will be responded. Then, we will have the permission to send emails to any mail receiver we want. (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html)
